### PR TITLE
fix: `find` function doesn't exist

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -208,7 +208,7 @@ updates, and refreshes the hub view after starting the server."
   (interactive)
   (when-let* ((server (tabulated-list-get-entry))
               (name (elt server 0))
-              (server-arg (find name mcp-hub-servers :key #'car :test #'equal)))
+              (server-arg (cl-find name mcp-hub-servers :key #'car :test #'equal)))
     (mcp-hub--start-server server-arg)
     (mcp-hub-update)))
 


### PR DESCRIPTION
When I tried to start a server by pressing `s` inside the mcp-hub buffer. One error popped out:

> Symbol’s function definition is void: find

I went looking for a function called `find` but couldn't locate it, so I've changed the call to `cl-find` instead and the error was gone.

**Details**:
- Emacs 30.1
- MacOS M1