### PR TITLE
fix: unknow `find` to `cl-find` in file `mcp-hub.el` function `mcp-hub-start-server`

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -208,7 +208,7 @@ updates, and refreshes the hub view after starting the server."
   (interactive)
   (when-let* ((server (tabulated-list-get-entry))
               (name (elt server 0))
-              (server-arg (find name mcp-hub-servers :key #'car :test #'equal)))
+              (server-arg (cl-find name mcp-hub-servers :key #'car :test #'equal)))
     (mcp-hub--start-server server-arg)
     (mcp-hub-update)))
 


### PR DESCRIPTION
Use function `mcp-hub-start-server` output: 
```
mcp-hub-start-server
and: Symbol’s function definition is void: find
```
This pr fix it.