### PR TITLE
Fixed the error of start-server directly if buffer *Mcp-Hub* does not exist. Error running timer: (error "No buffer named *Mcp-Hub*")

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -177,7 +177,7 @@ including connection status, available tools, resources, and prompts."
                                                                    (plist-get server :prompts)))
                                                    (list "nil" "nil" "nil")))))
                                    server-list)))
-    (with-current-buffer "*Mcp-Hub*"
+    (with-current-buffer (get-buffer-create "*Mcp-Hub*")
       (setq tabulated-list-entries
             (cl-mapcar #'(lambda (statu index)
                            (list (format "%d" index)


### PR DESCRIPTION
When starting the server, if *Mcp-Hub* does not exist, an error output will be reported:
```
Error running timer: (error "No buffer named *Mcp-Hub*")
```
This PR fixes it, for example configuration:
```
(add-hook 'after-init-hook
          #'mcp-hub-start-all-server)
```
Now, I can use it happily when Emacs is started.
Please don't think I'm doing PR scores, you can reject me, but hope you fix it, HHHHHH
Thank you for making my coding work even more fun.