### PR TITLE
fix: Improve JSON schema parsing and logging

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -570,7 +570,7 @@ Returns a plist representing the parsed schema, or nil if the input is invalid."
   (cond
    ;; Handle anyOf schemas
    ((plist-member input-schema :anyOf)
-    `(:type "any"
+    `(:type any
       :description ,(plist-get input-schema :description)
       :anyOf ,(mapcar #'mcp--parse-json-schema (plist-get input-schema :anyOf))))
 

--- a/mcp.el
+++ b/mcp.el
@@ -614,8 +614,8 @@ Returns a plist representing the parsed schema, or nil if the input is invalid."
                      (plist-get input-schema :defalut))))))))
 
    ;; Return a default for unrecognized schemas
-   (t `(:type "any"
-        :description ,(or (plist-get input-schema :description) "Unknown schema type")))))
+   (t `(:type any
+              :description ,(or (plist-get input-schema :description) "Unknown schema type")))))
 
 (defun mcp--parse-tool-args (properties required)
   "Parse tool arguments from PROPERTIES and REQUIRED lists.

--- a/mcp.el
+++ b/mcp.el
@@ -570,9 +570,13 @@ Returns a plist representing the parsed schema, or nil if the input is invalid."
   (cond
    ;; Handle anyOf schemas
    ((plist-member input-schema :anyOf)
-    `(:type any
+    `(
+      :type any
       :description ,(plist-get input-schema :description)
-      :anyOf ,(mapcar #'mcp--parse-json-schema (plist-get input-schema :anyOf))))
+      :anyOf ,(mapcar #'mcp--parse-json-schema (plist-get input-schema :anyOf))
+      ,@(when (plist-member input-schema :default)
+          (list :default
+                (plist-get input-schema :default)))))
 
    ;; Handle regular type-based schemas
    ((plist-get input-schema :type)
@@ -588,7 +592,8 @@ Returns a plist representing the parsed schema, or nil if the input is invalid."
                                    (seq-partition properties 2))
             :required required)))
         (_
-         `(:type ,type
+         `(
+           :type ,type
            :description ,(if (plist-member input-schema :description)
                              (plist-get input-schema :description)
                            "")
@@ -610,8 +615,8 @@ Returns a plist representing the parsed schema, or nil if the input is invalid."
                (list :enum
                      (plist-get input-schema :enum)))
            ,@(when (plist-member input-schema :default)
-               (list :defalut
-                     (plist-get input-schema :defalut))))))))
+               (list :default
+                     (plist-get input-schema :default))))))))
 
    ;; Return a default for unrecognized schemas
    (t `(:type any


### PR DESCRIPTION
This fixes #13 .

Key changes:
1. Restructured to use `cond` instead of `when-let*` as the top-level control flow
2. Added explicit handling for `:anyOf` schema types
3. Added a fallback case to handle schemas with no recognized pattern
4. Preserved all existing functionality for standard JSON schema types
5. Guard against empty `required` in schema (replace with empty list)

Note that `:anyOf` schemas don't have a `:type` at the top level - they have types inside the options array.


