### PR TITLE
Fix invalid session ID

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -223,7 +223,7 @@ LINES is a list of strings from an SSE event stream."
                         ;; Handle endpoint events
                         ((string-prefix-p "event: endpoint" msg)
                          (when-let* ((data (mcp--get-data messages)))
-                           (setf (mcp--endpoint conn) data)))
+			    (setf (mcp--endpoint conn) (string-trim data))))
 
                         ;; Handle message events
                         ((string-prefix-p "data: " msg)


### PR DESCRIPTION
vibe coded this fix.

The trailing `%0D` (carriage return) in the session ID caused the 400 error. The fixed logs show the corrected session ID without trailing characters:

**Before:**  
`POST /messages/?session_id=4ccb3bf809134120a91edfc21acadec4%0D` → 400 Bad Request

**After:**  
`POST /messages/?session_id=12b2157448694d32a82c17b6145d7e1e` → works correctly
