### PR TITLE
parse-tool-args: dont convert type to symbol

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -543,16 +543,10 @@ Returns a list of parsed argument plists."
                         (length required))))
     (cl-mapcar #'(lambda (arg-value required-name)
                    (pcase-let* ((`(,key ,value) arg-value))
-                     `(
-                       :name ,(substring (symbol-name key)
-                                         1)
-                       ,@(if (plist-member value :type)
-                             (plist-put value
-                                        :type
-                                        (intern (plist-get value :type)))
-                           value)
-                       ,@(unless required-name
-                           (list :optional t)))))
+                     `( :name ,(substring (symbol-name key) 1)
+                        ,@value
+                        ,@(unless required-name
+                            `(:optional t)))))
                (seq-partition properties 2)
                (append required
                        (when (> need-length 0)


### PR DESCRIPTION
In `gptel`, the `gptel--preprocess-tool-args` will converting the `type` from symbol to string if it's symbol.
By not converting `type` to symbol here, we save that conversion since the `gptel` will not have to convert back from symbol to string for `type`.