### PR TITLE
mcp--process-filter: handle the case where data is obvious not partial jsonrpc message

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -239,9 +239,12 @@ The message is sent differently based on connection type:
                  (when (not (= index (- (length parsed-messages) 1)))
                    (jsonrpc--warn "Invalid JSON: %s %s"
                                   (cdr err) json-str))
-                 (message "parse error")
-                 ;; Save remaining data to pending for next processing
-                 (process-put proc 'jsonrpc-pending json-str)))
+                 (if (string-prefix-p "{" json-str)
+                     ;; Save remaining data to pending for next processing
+                     (process-put proc 'jsonrpc-pending json-str)
+                   ;; When the data is obviously not a partial json message, the
+                   ;; server might be sending bogus data, we can ignore it
+                   (message "parse error"))))
               (when json
                 (setq json (plist-put json :jsonrpc-json json-str))
                 (push json queue)))))


### PR DESCRIPTION
When the partial data is obviously not partial jsonrpc message, we should just ignore it instead of try to concat it with the next message as it will keep causing json parsing to fail