### PR TITLE
mcp-hub--start-server: check inited-callback before calling

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -57,7 +57,8 @@ receives no arguments."
                        :tools-callback
                        #'(lambda (_ _)
                            (mcp-hub-update)
-                           (funcall inited-callback))
+                           (when inited-callback
+                             (funcall inited-callback)))
                        :prompts-callback
                        #'(lambda (_ _)
                            (mcp-hub-update))


### PR DESCRIPTION
Else the `mcp-hub-start-server` will fail