### PR TITLE
mcp-hub: start all server when has prefix arg

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -121,8 +121,9 @@ Optional argument SERVERS is a list of server names (strings) to filter which
 servers should be started. When nil, all configured servers are considered."
   (interactive)
   (let* ((servers-to-start (cl-remove-if (lambda (server)
-                                           (or (not (cl-find (car server) servers :test #'string=))
-                                               (gethash (car server) mcp-server-connections)))
+                                           (if servers
+                                               (not (cl-find (car server) servers :test #'string=))
+                                             (gethash (car server) mcp-server-connections)))
                                          mcp-hub-servers))
          (total (length servers-to-start))
          (started 0))

--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -228,13 +228,16 @@ including connection status, available tools, resources, and prompts."
       (tabulated-list-print t))))
 
 ;;;###autoload
-(defun mcp-hub ()
-  "View mcp hub server."
-  (interactive)
+(defun mcp-hub (&optional start)
+  "View mcp hub server.
+Start all server if START is non-nil or if called interactively with a prefix
+argument."
+  (interactive "P")
   ;; start all server
-  (when (and mcp-hub-servers
-           (= (hash-table-count mcp-server-connections)
-              0))
+  (when (and start
+             mcp-hub-servers
+             (= (hash-table-count mcp-server-connections)
+                0))
     (mcp-hub-start-all-server))
   ;; show buffer
   (pop-to-buffer "*Mcp-Hub*" nil)


### PR DESCRIPTION
Currently we auto start all server when invoke `mcp-hub`. That can be undesirable.
This PR changes the default to that `mcp-hub` will not start all servers, however when it's invoked with `C-u M-x mcp-hub`, all servers will be started.

Also check `servers` before filter the current server out of the to-start list. Else with empty `servers`, all will be filtered out and no server can be started