### PR TITLE
feat: add support for template resources

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -65,6 +65,9 @@ receives no arguments."
                        :resources-callback
                        #'(lambda (_ _)
                            (mcp-hub-update))
+                       :resources-templates-callback
+                       #'(lambda (_ _)
+                           (mcp-hub-update))
                        :error-callback
                        #'(lambda (_ _)
                            (mcp-hub-update))))))
@@ -174,6 +177,7 @@ Returns a list of server statuses, where each status is a plist containing:
 - :status - Either `connected' or `stop'
 - :tools - Available tools (if connected)
 - :resources - Available resources (if connected)
+- :template-resources - Available template resources (if connected)
 - :prompts - Available prompts (if connected)"
   (mapcar #'(lambda (server)
               (let ((name (car server)))
@@ -183,6 +187,7 @@ Returns a list of server statuses, where each status is a plist containing:
                           :status (mcp--status connection)
                           :tools (mcp--tools connection)
                           :resources (mcp--resources connection)
+                          :template-resources (mcp--template-resources connection)
                           :prompts (mcp--prompts connection))
                   (list :name name :status 'stop))))
           mcp-hub-servers))
@@ -192,7 +197,8 @@ Returns a list of server statuses, where each status is a plist containing:
 If called interactively, ARG is the prefix argument.
 When SILENT is non-nil, suppress any status messages.
 This function refreshes the *Mcp-Hub* buffer with the latest server information,
-including connection status, available tools, resources, and prompts."
+including connection status, available tools, resources, template resources and
+prompts."
   (interactive "P")
   (when-let* ((server-list (mcp-hub-get-servers))
               (server-show (mapcar #'(lambda (server)
@@ -215,8 +221,9 @@ including connection status, available tools, resources, and prompts."
                                                                          (length x)))
                                                              (list (plist-get server :tools)
                                                                    (plist-get server :resources)
+                                                                   (plist-get server :template-resources)
                                                                    (plist-get server :prompts)))
-                                                   (list "nil" "nil" "nil")))))
+                                                   (list "nil" "nil" "nil" "nil")))))
                                    server-list)))
     (with-current-buffer (get-buffer-create "*Mcp-Hub*")
       (setq tabulated-list-entries
@@ -294,6 +301,7 @@ currently highlighted in the *Mcp-Hub* buffer."
          ("Status" 15 t)
          ("Tools" 10 t)
          ("Resources" 10 t)
+         ("Template" 10 t)
          ("Prompts" 10 t)])
   (setq tabulated-list-padding 2)
   (setq tabulated-list-sort-key '("Name" . nil))


### PR DESCRIPTION
Hi, I dont' know if this can be useful but I noticed that resource templates were not exposed.

This PR expose template resources within the MCP Hub. 