### PR TITLE
Fix JSON parsing for large messages over 24KB

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -457,8 +457,12 @@ The message is sent differently based on connection type:
                                          :null-object nil
                                          :false-object :json-false))
               (json-parse-error
-               ;; parse error and not because of incomplete json
-               (jsonrpc--warn "Invalid JSON: %s\t %s" (cdr err) json-str))
+               ;; For incomplete JSON, save to buffer instead of warning
+               (if (equal type 'stdio)
+                   (with-current-buffer buf
+                     (erase-buffer)
+                     (insert json-str))
+                 (jsonrpc--warn "Invalid JSON: %s\t %s" (cdr err) json-str)))
               (json-end-of-file
                ;; Save remaining data to pending for next processing
                (with-current-buffer buf


### PR DESCRIPTION
- Modified json-parse-error handling in mcp--process-filter
- Large messages were being split across multiple chunks causing parse errors
- Now accumulates incomplete JSON in buffer for stdio connections
- Fixes issue where files >24KB couldn't be read via MCP filesystem server