### PR TITLE
mcp-stop-server: ignore error on shutdown

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -802,7 +802,8 @@ from `mcp-server-connections'. If no server with the given NAME is found,
 a message will be displayed indicating that the server is not running."
   (if-let* ((connection (gethash name mcp-server-connections)))
       (progn
-        (jsonrpc-shutdown connection)
+        (ignore-errors
+          (jsonrpc-shutdown connection))
         (setf (mcp--status connection) 'stop))
     (message "mcp %s server not started" name)))
 


### PR DESCRIPTION
If the connection doesn't include any process (sse/http server case?) the `jsonrpc-shutdown connection` will fail.
It would be better for us to ignore any error on that since we're on the way out already