### PR TITLE
mcp-async-initialize-message: check if connection type support mcp--sse

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -998,7 +998,9 @@ with the client's capabilities and version information."
                                       (jsonrpc-name connection) code message)))
                          :timeout mcp-server-start-time
                          :timeout-fn (lambda ()
-                                       (unless (and check-sse (mcp--sse connection))
+                                       (unless (and check-sse
+                                                    (mcp-http-process-connection-p connection)
+                                                    (mcp--sse connection))
                                          (if error-callback
                                              (funcall error-callback 124 "timeout")
                                            (message "Sadly, mcp server (%s) timed out"


### PR DESCRIPTION
Else the `mcp--sse` will fail for stdio connection.
We can probably move this check higher into `check-sse`, but given the name and the usage of `mcp--sse`, it would be better to check if the connection can be used with `mcp--sse`.