### PR TITLE
mcp: support access token per spec 2.6

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -307,7 +307,8 @@ The message is sent differently based on connection type:
                                      (setf (mcp--session-id connection)
                                            session-id))
                                    ;; connect sse
-                                   (unless (jsonrpc--process connection)
+                                   (when (and (mcp--sse connection)
+                                              (not (jsonrpc--process connection)))
                                      (mcp--connect-sse connection))
                                    (unless (mcp--sse connection)
                                      (let (data json)


### PR DESCRIPTION
Support access token according to https://modelcontextprotocol.io/specification/draft/basic/authorization#access-token-usage
Tested with remote Github MCP server https://github.com/github/github-mcp-server/releases/tag/v0.5.0

An example of configuration inside `mcp-hub-servers`

``` elisp
     ("github" :url "https://api.githubcopilot.com/mcp/"
      :token ,(lambda () (getenv "GH_PAT")))
```