### PR TITLE
mcp-hub revert throws error, local variables are not set when visiting mcp hub

### DIFF
--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -193,7 +193,7 @@ Returns a list of server statuses, where each status is a plist containing:
                 (list :name name :status 'stop))))
           mcp-hub-servers))
 
-(defun mcp-hub-update ()
+(defun mcp-hub-update (&optional ignore-auto noconfirm)
   "Update the MCP Hub display with current server status.
 If called interactively, ARG is the prefix argument.
 When SILENT is non-nil, suppress any status messages.
@@ -241,6 +241,7 @@ prompts."
 Start all server if START is non-nil or if called interactively with a prefix
 argument."
   (interactive "P")
+  (hack-dir-local-variables-non-file-buffer) ; ensure dir-locals before using mcp-hub-servers
   ;; start all server
   (when (and start
              mcp-hub-servers

--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -201,6 +201,7 @@ This function refreshes the *Mcp-Hub* buffer with the latest server information,
 including connection status, available tools, resources, template resources and
 prompts."
   (interactive)
+  (ignore ignore-aut noconfirm) ; unused variables
   (when-let* ((server-list (mcp-hub-get-servers))
               (server-show (mapcar (lambda (server)
                                      (let* ((name (plist-get server :name))

--- a/mcp-hub.el
+++ b/mcp-hub.el
@@ -201,7 +201,7 @@ This function refreshes the *Mcp-Hub* buffer with the latest server information,
 including connection status, available tools, resources, template resources and
 prompts."
   (interactive)
-  (ignore ignore-aut noconfirm) ; unused variables
+  (ignore ignore-auto noconfirm) ; unused variables
   (when-let* ((server-list (mcp-hub-get-servers))
               (server-show (mapcar (lambda (server)
                                      (let* ((name (plist-get server :name))


### PR DESCRIPTION
revert-buffer-function receives optional parameters which cause error when hitting "g" on mcp-hub.

dir-local variables that customize mcp-hub variables are not applied when visiting mcp hub.