### PR TITLE
fix: properly parse Content-Type header by handling semicolon-separated parameters

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -318,7 +318,7 @@ The message is sent differently based on connection type:
                                      (mcp--connect-sse connection))
                                    (unless (mcp--sse connection)
                                      (let (data json)
-                                       (pcase (plist-get headers-plist :content-type)
+                                       (pcase (car (split-string (plist-get headers-plist :content-type) ";" t))
                                          ("text/event-stream"
                                           (dolist (line (split-string body "\n"))
                                             (cond


### PR DESCRIPTION
The previous implementation directly compared the Content-Type header value, which could fail when the header includes additional parameters like charset. This change splits the Content-Type on semicolons and uses only the main media type for comparison, ensuring proper handling of text/event-stream, application/json content types with parameters.