### PR TITLE
Send empty object {} instead of null for */list params

### DIFF
--- a/mcp.el
+++ b/mcp.el
@@ -1214,7 +1214,7 @@ SYNCP specifies if the operation should be synchronous or asynchronous."
                        (message "Sadly, %s mpc server reports %s: %s"
                                 (jsonrpc-name connection) code message))))
          (args `(,connection
-                 ,method nil
+                 ,method ,(make-hash-table)
                  :timeout ,(mcp--timeout connection)
                  ,@(unless syncp `(:success-fn
                                    ,success-fn))


### PR DESCRIPTION
### Problem

`mcp--list-items` passed `params` as `nil`, which serializes to `"params":null`. Servers fronted by the `mcp-remote` proxy validate params with a strict (Zod) schema that rejects `null`, so `tools/list` (and `prompts/list`, `resources/list`) are dropped by the proxy and never answered. The connection reaches `connected` and advertises a tools capability, but `mcp--tools` stays empty.

### Fix

Send an empty hash table instead, which serializes to `"params":{}` — the spec-correct value for empty params, accepted by both strict (mcp-remote) and lenient servers.

Verified locally against an `mcp-remote`-fronted server: `tools/list` now returns the full tool set.

Fixes #85
